### PR TITLE
Fixed minor bug with patch request's body containing single quotes

### DIFF
--- a/src/controllers/task.js
+++ b/src/controllers/task.js
@@ -230,10 +230,17 @@ const TaskController = (taskModel, userModel, authService, googleAPIService) => 
         // get all the info from what the user wants to edit and change it into a string
         const body = req.body;
         const updates = [];
-        for (let key in body)
+
+        for (let key in body) {
             if (body.hasOwnProperty(key)) {
-                updates.push(key + "=" + "\'" + body[key] + "\'");
+                let value = body[key];
+                if (typeof(value) === 'string') {
+                    const newVal = value.replace(/\'/g, "\'\'");
+                    value = newVal;
+                }
+                updates.push(key + "=" + "\'" + value + "\'");
             }
+        }
         const updatedTask = updates.join(",");
         
         const [update, edit_err] = await taskModel.editTask(id, updatedTask);


### PR DESCRIPTION
I found a small bug where the patch request will fail if the editing content contains single quotes because of SQL syntax, i.e. `description='i'm going out'` will fail but `description='i''m going out'` will not. So, I added code to process the body's contents and escape all single quotes by replacing them with double single quotes before converting it to a string for the query request.

<img width="1440" alt="Screen Shot 2020-05-21 at 8 52 42 AM" src="https://user-images.githubusercontent.com/50340495/82578231-f93da380-9b40-11ea-9e2b-a05f5d232e25.png">
