### PR TITLE
Prioritize shorter tasks

### DIFF
--- a/src/models/task/postgres.js
+++ b/src/models/task/postgres.js
@@ -1,5 +1,5 @@
 const TaskRepo = (postgres) => {
-    const createTaskTableSQL = `
+  const createTaskTableSQL = `
         CREATE TABLE IF NOT EXISTS tasks(
             id SERIAL PRIMARY KEY,
             user_id text NOT NULL,
@@ -21,217 +21,228 @@ const TaskRepo = (postgres) => {
         );
     `;
 
-    const setupRepo = async () => {
-        try {
-            const client = await postgres.connect();
-            await client.query(createTaskTableSQL);
-            client.release();
-            console.log('Task Table Created');
-            return null;
-        } catch (err) {
-            return err;
-        }
+  const setupRepo = async () => {
+    try {
+      const client = await postgres.connect();
+      await client.query(createTaskTableSQL);
+      client.release();
+      console.log('Task Table Created');
+      return null;
+    } catch (err) {
+      return err;
     }
+  };
 
-    const createTaskSQL = `
+  const createTaskSQL = `
         INSERT INTO tasks(name, description, duration, due_date, scheduled, completed, user_id)
         VALUES ($1, $2, $3, $4, FALSE, FALSE, $5)
         RETURNING *;
     `;
 
-    const createTask = async (name, description, duration, due_date, user_id) => {
-        const values = [name, description, duration, due_date, user_id];
-        try {
-            const client = await postgres.connect();
-            const res = await client.query(createTaskSQL, values);
-            client.release();
-            return [res.rows[0], null];
-        } catch (err) {
-            return [null, err];
-        }
-    };
+  const createTask = async (name, description, duration, due_date, user_id) => {
+    const values = [name, description, duration, due_date, user_id];
+    try {
+      const client = await postgres.connect();
+      const res = await client.query(createTaskSQL, values);
+      client.release();
+      return [res.rows[0], null];
+    } catch (err) {
+      return [null, err];
+    }
+  };
 
-    const getTaskByIDSQL = `
+  const getTaskByIDSQL = `
         SELECT * FROM tasks WHERE id=$1;
     `;
 
-    const getTaskByID = async (id) => {
-        const values = [id];
-        try {
-            const client = await postgres.connect();
-            const res = await client.query(getTaskByIDSQL, values);
-            client.release();
-            return [res.rows[0], null];
-        } catch (err) {
-            return [null, err];
-        }
-    };
+  const getTaskByID = async (id) => {
+    const values = [id];
+    try {
+      const client = await postgres.connect();
+      const res = await client.query(getTaskByIDSQL, values);
+      client.release();
+      return [res.rows[0], null];
+    } catch (err) {
+      return [null, err];
+    }
+  };
 
-    const setTaskCompleteSQL = `
+  const setTaskCompleteSQL = `
         UPDATE tasks SET completed=true, completed_time=CURRENT_TIMESTAMP, updated_time=CURRENT_TIMESTAMP
         WHERE id=$1
         RETURNING *;
-    `
-    const setTaskCompleted = async (taskID) => {
-        const values = [taskID];
-        try {
-            const client = await postgres.connect(); //client is an object that has a connection to DB 
-            const res = await client.query(setTaskCompleteSQL, values);
-            client.release();
-            if (res.rows[0] == undefined)
-                return [null, "Invalid ID"];
-            return [res.rows[0], ""]; //requires null because no error in this case
-        } catch (err) {
-            return [null, err]; // return null for the actual object, the error should not be null
-        }
+    `;
+  const setTaskCompleted = async (taskID) => {
+    const values = [taskID];
+    try {
+      const client = await postgres.connect(); //client is an object that has a connection to DB
+      const res = await client.query(setTaskCompleteSQL, values);
+      client.release();
+      if (res.rows[0] == undefined) return [null, 'Invalid ID'];
+      return [res.rows[0], '']; //requires null because no error in this case
+    } catch (err) {
+      return [null, err]; // return null for the actual object, the error should not be null
     }
+  };
 
-    const getAllCompletedTasksSQL = `
+  const getAllCompletedTasksSQL = `
         SELECT * FROM tasks WHERE user_id=$1 AND completed=TRUE ORDER BY completed_time DESC;
     `;
 
-    const getAllCompletedTasks = async (userID) => {
-        const values = [userID];
-        try {
-            const client = await postgres.connect();
-            const res = await client.query(getAllCompletedTasksSQL, values);
-            client.release();
-            return [res.rows, null] // error message is empty string
-        } catch (err) {
-            return [null, "Error at Completed Tasks"]; // return null for the data if user's tasks DNE
-        }
+  const getAllCompletedTasks = async (userID) => {
+    const values = [userID];
+    try {
+      const client = await postgres.connect();
+      const res = await client.query(getAllCompletedTasksSQL, values);
+      client.release();
+      return [res.rows, null]; // error message is empty string
+    } catch (err) {
+      return [null, 'Error at Completed Tasks']; // return null for the data if user's tasks DNE
     }
+  };
 
-    const getAllScheduledTasksSQL = `
+  const getAllScheduledTasksSQL = `
         SELECT * FROM tasks WHERE user_id=$1 AND scheduled=TRUE ORDER BY start_time;
     `;
 
-    const getAllScheduledTasks = async (userID) => {
-        const values = [userID];
-        try {
-            const client = await postgres.connect();
-            const res = await client.query(getAllScheduledTasksSQL, values);
-            client.release();
-            return [res.rows, null] // error message is empty string
-        } catch (err) {
-            return [null, "Error at Scheduled"]; // return null  for the data if user's tasks DNE
-        }
+  const getAllScheduledTasks = async (userID) => {
+    const values = [userID];
+    try {
+      const client = await postgres.connect();
+      const res = await client.query(getAllScheduledTasksSQL, values);
+      client.release();
+      return [res.rows, null]; // error message is empty string
+    } catch (err) {
+      return [null, 'Error at Scheduled']; // return null  for the data if user's tasks DNE
     }
+  };
 
-    const getAllNotScheduledTasksSQL = `
+  const getAllNotScheduledTasksSQL = `
         SELECT * FROM tasks WHERE user_id=$1 AND scheduled = FALSE ORDER BY updated_time DESC;
     `;
 
-    const getAllNotScheduledTasks = async (userID) => {
-        const values = [userID];
-        try {
-            const client = await postgres.connect();
-            const res = await client.query(getAllNotScheduledTasksSQL, values);
-            client.release();
-            return [res.rows, null] // error message is empty string 
-        } catch (err) {
-            return [null, "Error at Not Scheduled"]; // return null  for the data if user's tasks DNE
-        }
+  const getAllNotScheduledTasks = async (userID) => {
+    const values = [userID];
+    try {
+      const client = await postgres.connect();
+      const res = await client.query(getAllNotScheduledTasksSQL, values);
+      client.release();
+      return [res.rows, null]; // error message is empty string
+    } catch (err) {
+      return [null, 'Error at Not Scheduled']; // return null  for the data if user's tasks DNE
     }
+  };
 
-    const getTasksForSchedulingSQL = `
-        SELECT * FROM tasks WHERE user_id=$1 AND id = ANY($2) AND scheduled = FALSE ORDER BY due_date ASC;
+  const getTasksForSchedulingSQL = `
+        SELECT * FROM tasks WHERE user_id=$1 AND id = ANY($2) AND scheduled = FALSE ORDER BY due_date, duration;
     `;
 
-    const getTasksForScheduling = async (userID, task_ids) => {
-        const values = [userID, task_ids];
-        // console.log(values);
-        try {
-            const client = await postgres.connect();
-            const res = await client.query(getTasksForSchedulingSQL, values);
-            client.release();
-            return [res.rows, null] // error message is empty string 
-        } catch (err) {
-            return [null, "Error retrieving tasks for scheduling"]; // return null  for the data if user's tasks DNE
-        }
+  const getTasksForScheduling = async (userID, task_ids) => {
+    const values = [userID, task_ids];
+    // console.log(values);
+    try {
+      const client = await postgres.connect();
+      const res = await client.query(getTasksForSchedulingSQL, values);
+      client.release();
+      return [res.rows, null]; // error message is empty string
+    } catch (err) {
+      return [null, 'Error retrieving tasks for scheduling']; // return null  for the data if user's tasks DNE
     }
+  };
 
-    const scheduleTaskSQL = `
+  const scheduleTaskSQL = `
         UPDATE tasks SET scheduled_time=$2 WHERE id=$1
         RETURNING *;
-    `
+    `;
 
-    const scheduleTask = async (taskID, scheduledTime) => {
-        const values = [taskID, scheduledTime];
-        try {
-            const client = await postgres.connect();
-            const res = await client.query(scheduleTaskSQL, values);
-            client.release();
-            return [res.rows[0], ""];
-        } catch (err) {
-            return [null, err];
-        }
+  const scheduleTask = async (taskID, scheduledTime) => {
+    const values = [taskID, scheduledTime];
+    try {
+      const client = await postgres.connect();
+      const res = await client.query(scheduleTaskSQL, values);
+      client.release();
+      return [res.rows[0], ''];
+    } catch (err) {
+      return [null, err];
     }
+  };
 
-    const confirmScheduleSQL = `
+  const confirmScheduleSQL = `
         UPDATE tasks SET scheduled=true, event_id=$2, calendar_id=$3, event_url=$4, start_time=$5, end_time=$6
         WHERE id=$1
         RETURNING *;
-    `
+    `;
 
-    const confirmSchedule = async (taskID, eventID, calendarID, eventURL, startTime, endTime) => {
-        const values = [taskID, eventID, calendarID, eventURL, startTime, endTime];
-        try {
-            const client = await postgres.connect();
-            const res = await client.query(confirmScheduleSQL, values);
-            client.release();
-            return [res.rows[0], ""];
-        } catch (err) {
-            return [null, err];
-        }
+  const confirmSchedule = async (
+    taskID,
+    eventID,
+    calendarID,
+    eventURL,
+    startTime,
+    endTime,
+  ) => {
+    const values = [taskID, eventID, calendarID, eventURL, startTime, endTime];
+    try {
+      const client = await postgres.connect();
+      const res = await client.query(confirmScheduleSQL, values);
+      client.release();
+      return [res.rows[0], ''];
+    } catch (err) {
+      return [null, err];
     }
+  };
 
-    const deleteTaskSQL = `
+  const deleteTaskSQL = `
         DELETE FROM tasks 
         WHERE id=$1
         RETURNING scheduled, event_id;
-    `
+    `;
 
-    const deleteTask = async (taskID) => {
-        const values = [taskID];
-        try {
-            const client = await postgres.connect();
-            const res = await client.query(deleteTaskSQL, values);
-            client.release();
-            return [res.rows[0], null];
-        } catch (err) {
-            return [null, err];
-        }
+  const deleteTask = async (taskID) => {
+    const values = [taskID];
+    try {
+      const client = await postgres.connect();
+      const res = await client.query(deleteTaskSQL, values);
+      client.release();
+      return [res.rows[0], null];
+    } catch (err) {
+      return [null, err];
     }
+  };
 
-    const editTask = async (taskID, updatedTask) => {
-        try {
-            const client = await postgres.connect();
-            query = "UPDATE tasks SET " + updatedTask + ", updated_time=NOW() WHERE id=" + taskID + " RETURNING * ;";
-            const res = await client.query(query);
-            client.release();
-            return [res.rows[0], null];
-        } catch (err) {
-            return [null,err];
-        }
+  const editTask = async (taskID, updatedTask) => {
+    try {
+      const client = await postgres.connect();
+      query =
+        'UPDATE tasks SET ' +
+        updatedTask +
+        ', updated_time=NOW() WHERE id=' +
+        taskID +
+        ' RETURNING * ;';
+      const res = await client.query(query);
+      client.release();
+      return [res.rows[0], null];
+    } catch (err) {
+      return [null, err];
     }
+  };
 
-    return {
-        setupRepo,
-        createTask,
-        getTaskByID,
-        setTaskCompleted,
-        getAllCompletedTasks,
-        getAllNotScheduledTasks,
-        getTasksForScheduling,
-        getAllScheduledTasks,
-        scheduleTask,
-        confirmSchedule,
-        deleteTask,
-        editTask
-    };
-}
+  return {
+    setupRepo,
+    createTask,
+    getTaskByID,
+    setTaskCompleted,
+    getAllCompletedTasks,
+    getAllNotScheduledTasks,
+    getTasksForScheduling,
+    getAllScheduledTasks,
+    scheduleTask,
+    confirmSchedule,
+    deleteTask,
+    editTask,
+  };
+};
 
 module.exports = {
-    TaskRepo
-}
+  TaskRepo,
+};


### PR DESCRIPTION
## Summary
Currently, our scheduling algorithm tries to fit as many tasks as possible.

This update changes its priorities:
1. Prefer schedules that fit earlier due tasks over later due tasks
2. Prefer schedules that fit shorter tasks over longer ones

## Examples
### Shorter Task Prioritization
* Both Task 1 and Task 2 are due at 4 PM on Tuesday.
* There is a 45 minute window between 3:15 and 4 PM available.
* Both tasks cannot fit, but because Task 2 is shorter, it is scheduled.

![image](https://user-images.githubusercontent.com/13477221/82852227-33979f80-9eb7-11ea-9f72-dff2fd7dc063.png)
![image](https://user-images.githubusercontent.com/13477221/82852232-398d8080-9eb7-11ea-9506-fba570eb4df5.png)

### Earlier Due Date Prioritization
* []day’s task means the task is due on []day
* Scenario 1:
  * We schedule Tuesday’s task
  * We schedule Wednesday’s task
  * Thursday’s task cannot be scheduled
* Scenario 2:
  * We schedule Tuesday’s task
  * We schedule Thursday’s task
  * Wednesday’s task cannot be scheduled
* Even though 2 tasks are scheduled in both scenarios, the algorithm picks scenario 1 because we prefer tasks with earlier due dates to be scheduled first

![image](https://user-images.githubusercontent.com/13477221/82852316-84a79380-9eb7-11ea-8a10-82eb71b28799.png)

### Shorter Task + Earlier Due Date Prioritization
* Combination scenario of the above two examples
* Because of the priorities, the shorter task due on Wednesday is scheduled

![image](https://user-images.githubusercontent.com/13477221/82852363-a143cb80-9eb7-11ea-8eb1-be36c8c239ea.png)

